### PR TITLE
Fix for issue 13 - Update 20160609

### DIFF
--- a/lazy_mofo.php
+++ b/lazy_mofo.php
@@ -845,6 +845,8 @@ class lazy_mofo{
         // add limit and offset for pagination
         if($_pagination_off == 0 && $_export == 0)
             $sql .= " limit $_offset, $grid_limit"; 
+		
+	$sql = str_replace('[ORDER_BY]','ORDER BY',$sql); // Handle ORDER BY in other parts of grid_sql statement
 
         // run query
         $result = $this->query($sql, $sql_param, 'grid() run query');
@@ -1675,6 +1677,7 @@ class lazy_mofo{
         $sql = preg_replace('/order\s+by\s+.+$/i', '', $sql);   // remove order
         $sql = preg_replace('/limit\s+[0-9,\s]+$/i', '', $sql); // remove limit
         $sql .= ' limit 0 ';                                    // add limit
+	$sql = str_replace('[ORDER_BY]','ORDER BY',$sql); // Handle ORDER BY in other parts of grid_sql statement
 
         $sth = $this->dbh->prepare($sql);
         if(!$sth->execute($sql_param)){


### PR DESCRIPTION
Handle ORDER BY in other parts of grid_sql statement.

For grid_sql statements with many ORDER BY statements, indicate those not to be replaced using **[ORDER_BY]** in grid_sql

Also able to handle sort when user clicks on header, and hopefully does not break existing code.

Solution will look like...

```
SELECT
    j.LogId,j.Id,GROUP_CONCAT(L.Code [ORDER_BY] FIND_IN_SET(L.Id, j.Locations))
FROM
    job_log j
LEFT JOIN
    location L ON FIND_IN_SET(L.Id, j.Locations) != 0 
WHERE
    j.Id = 3
ORDER BY
    j.LogId
```
