### PR TITLE
Make exclude_field non visible in form input and edit mode

### DIFF
--- a/lazy_mofo.php
+++ b/lazy_mofo.php
@@ -65,6 +65,8 @@ class lazy_mofo{
     public $return_to_edit_after_insert = true; // redirect to edit screen after adding or updating a record. if false, user is sent back to grid view.
     public $return_to_edit_after_update = true; 
 
+    public $redirect_using_js = false; // redirect to a page using java-script instead of header modification by means of PHP. 
+
     // upload paths                             // relative path names only! paths are created at runtime as needed
     public $upload_path = 'uploads';            // required when using --image or --document input types
     public $thumb_path = 'thumbs';              // optional, leave blank if you don't need thumbnails
@@ -2280,10 +2282,13 @@ class lazy_mofo{
         }
         
         // this feature is only used used with WordPress plugins - use a simple js redirect for WP
-        if(mb_strlen($this->uri_path) > 0){
+        // or if $this->redirect_using_js is true
+        if(mb_strlen($this->uri_path) > 0 ||
+            $this->redirect_using_js ){
             echo "<script>window.location.href='$url';</script>";
             return;
         }
+       
 
         $port = '';    
         $host = preg_replace('/:[0-9]+$/', '', $_SERVER['HTTP_HOST']); // host without port number

--- a/lazy_mofo.php
+++ b/lazy_mofo.php
@@ -1685,8 +1685,12 @@ class lazy_mofo{
 
         $i = 0;
         $columns = array();
-        while($column = $sth->getColumnMeta($i++))
+        while($column = $sth->getColumnMeta($i++)){
+            if($context == 'form' && array_key_exists($column['name'], $this->exclude_field))
+                continue;
+
             array_push($columns, $column['name']);
+        }
 
         // quit now if there's nothing else to do
         if(!$this->auto_populate_controls)


### PR DESCRIPTION
Excluded fields should not be visible in edit or add row mode.

Selected fields for preview in the grid should not be affected by excluded fields because a user can precisely pick required fields by means of select statement "SELECT field1, field2, etc. from table".
