### PR TITLE
German language file and fixing unescaped ampersands

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 lazy mofo - php data grid for mysql - send bugs and feedback to iansoko at gmail
 
+version 2017-10-09
+------------------
+  Added German language file.
+  Fixed a typo and a view unescaped ampersands. Thx Raffael
+
 version 2017-09-29
 ------------------
   Added tweaks to support i18n/internationalization. Thx Raffael and Fabio.

--- a/i18n/de-de.php
+++ b/i18n/de-de.php
@@ -1,0 +1,79 @@
+<?php
+/*
+Instructions:
+
+- To contribute a localization file populate the variables below with standards of your language + country
+- For HTML inputs, only edit the value= attribute, but not if the value contains a [placeholder]
+- Don't edit [placeholders]
+- Name the file in the following format: 2letterlanguage-2lettercountry.php, for example en-us.php
+
+country codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+language codes: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+
+Thanks for your help!
+-Ian
+*/
+
+// javascript dialogs
+$this->delete_confirm      = 'Sind Sie sicher, dass Sie diesen Eintrag löschen möchten?';
+$this->update_grid_confirm = 'Sind Sie sicher, dass Sie diese [count] Einträge löschen möchten?';
+
+// form buttons
+$this->form_add_button    = "<input type='submit' value='Hinzufügen' class='lm_button'>";
+$this->form_update_button = "<input type='submit' value='Aktualisieren' class='lm_button'>"; 
+$this->form_back_button   = "<input type='button' value='&lt; Zurück' class='lm_button dull' onclick='_back();'>";
+$this->form_delete_button = "<input type='button' value='Löschen' class='lm_button error' onclick='_delete();'>"; 
+
+// titles in the <th> of top of the edit form 
+$this->form_text_title_add    = 'Eintrag hinzufügen';   
+$this->form_text_title_edit   = 'Eintrag bearbeiten';
+$this->form_text_record_saved = 'Eintrag gespeichert';
+$this->form_text_record_added = 'Eintrag hinzugefügt';
+
+// links on grid
+$this->grid_add_link    = "<a href='[script_name]action=edit&amp;[qs]' class='lm_grid_add_link'>Neuer Eintrag</a>";
+$this->grid_edit_link   = "<a href='[script_name]action=edit&amp;[identity_name]=[identity_id]&amp;[qs]'>[ändern]</a>";
+$this->grid_delete_link = "<a href='#' onclick='return _delete(\"[identity_id]\");'>[löschen]</a>";
+$this->grid_export_link = "<a href='[script_name]_export=1&amp;[qs]' title='CSV herunterladen'>Exportieren</a>";
+
+// search box
+$this->grid_search_box = "
+<form action='[script_name]' class='lm_search_box'>
+    <input type='text' name='_search' value='[_search]' size='20' class='lm_search_input'>
+    <a href='[script_name]' style='margin: 0 10px 0 -20px; display: inline-block;' title='Suche zurücksetzen'>x</a>
+    <input type='submit' class='lm_button lm_search_button' value='Suche'>
+    <input type='hidden' name='action' value='search'>[query_string_list]
+</form>"; 
+
+
+// grid messages
+$this->grid_text_record_added     = "Eintrag hinzugefügt";
+$this->grid_text_changes_saved    = "Änderungen gespeichert";
+$this->grid_text_record_deleted   = "Eintrag gelöscht";
+$this->grid_text_save_changes     = "Änderungen speichern";
+$this->grid_text_delete           = "Löschen";
+$this->grid_text_no_records_found = "Keine Einträge gefunden";
+
+// pagination text
+$this->pagination_text_use_paging = 'use paging';
+$this->pagination_text_show_all   = 'alle anzeigen';
+$this->pagination_text_records    = 'Einträge'; // singular: "Eintrag", looks better than "Eintrag/Einträge"
+$this->pagination_text_go         = 'aufrufen'; // not the best translation, but no better idea
+$this->pagination_text_page       = 'Seite';
+$this->pagination_text_of         = 'von';
+$this->pagination_text_next       = 'Nächste&gt;';
+$this->pagination_text_back       = '&lt;Vorherige';
+
+// delete upload link text
+$this->text_delete_image = 'Bild löschen';
+$this->text_delete_document = 'Dokument löschen';
+
+// relative paths for --image or --document uploads
+// paths are created at runtime as needed
+$this->upload_path = 'uploads';            // required when using  input types
+$this->thumb_path = 'thumbs';              // optional, leave blank if you don't need thumbnails
+
+// output date formats
+$this->date_out = 'd.m.Y';
+$this->datetime_out = 'd.m.Y, H:i';
+

--- a/lazy_mofo.php
+++ b/lazy_mofo.php
@@ -3,7 +3,7 @@
 // php crud datagrid for mysql and php5
 // MIT License - http://lazymofo.wdschools.com/
 // send feedback or questions iansoko at gmail
-// version 2017-09-29
+// version 2017-10-09
 
 class lazy_mofo{
 
@@ -181,7 +181,7 @@ class lazy_mofo{
         // load requested internationalization file, en-us is defined above, in this class
         if(strlen($i18n) > 0 && $i18n != 'en-us'){
             if(!file_exists("i18n/{$i18n}.php"))
-                die("Error: Requested i18n file ({$i18n}.php) does not exists.");
+                die("Error: Requested i18n file ({$i18n}.php) does not exist.");
             include("i18n/{$i18n}.php");    
         }
     }
@@ -942,7 +942,7 @@ class lazy_mofo{
             if($column_name == $this->identity_name && $i == ($column_count - 1))
                 $head .= "    <th></th>\n"; // if identity is last column then this is the column with the edit and delete links
             else
-                $head .= "    <th><a href='{$uri_path}_order_by=" . ($i + 1) . "&_desc=$_desc_invert&" . $this->get_qs('_search') . "'>$title</a></th>\n";
+                $head .= "    <th><a href='{$uri_path}_order_by=" . ($i + 1) . "&amp;_desc=$_desc_invert&amp;" . $this->get_qs('_search') . "'>$title</a></th>\n";
         
             $i++;
 
@@ -1788,18 +1788,18 @@ class lazy_mofo{
 
         $use_paging_link = '';
         if($_pagination_off == 1)
-            $use_paging_link = "<a href='{$uri_path}_pagination_off=0&$get' rel='nofollow'>$this->pagination_text_use_paging</a>";
+            $use_paging_link = "<a href='{$uri_path}_pagination_off=0&amp;$get' rel='nofollow'>$this->pagination_text_use_paging</a>";
 
         if($_pagination_off == 1 || $count <= $limit) 
             return number_format($count) . " $this->pagination_text_records $use_paging_link";
 
         // simple text input for page number on giant datasets. use drop-down for smaller datasets.
         if($count > 100000){
-            $input = "<input type='text' size='7' id='active_page_$id' value='$active_page' ><input type='button' value='$this->pagination_text_go' onclick='window.location.href=\"{$uri_path}_offset=\" + ((document.getElementById(\"active_page_$id\").value * $limit) - $limit) + \"&$get\"'>";
+            $input = "<input type='text' size='7' id='active_page_$id' value='$active_page' ><input type='button' value='$this->pagination_text_go' onclick='window.location.href=\"{$uri_path}_offset=\" + ((document.getElementById(\"active_page_$id\").value * $limit) - $limit) + \"&amp;$get\"'>";
         }
         else
         {
-            $input = "<select onchange='window.location.href=\"{$uri_path}_offset=\" + this.options[this.selectedIndex].value + \"&$get\"'>";
+            $input = "<select onchange='window.location.href=\"{$uri_path}_offset=\" + this.options[this.selectedIndex].value + \"&amp;$get\"'>";
             for($i = 0, $p = 1; $i < $count; $i += $limit, $p++){
                 $sel = '';
                 if($p == $active_page)
@@ -1815,14 +1815,14 @@ class lazy_mofo{
         if($_offset == 0)
             $pagination .= " $this->pagination_text_back ";
         else
-            $pagination .= " <a href='{$uri_path}_offset=" . ($_offset - $limit) . "&$get'>$this->pagination_text_back</a> ";
+            $pagination .= " <a href='{$uri_path}_offset=" . ($_offset - $limit) . "&amp;$get'>$this->pagination_text_back</a> ";
 
         if($active_page >= $total_page)
             $pagination  .= " $this->pagination_text_next ";
         else
-            $pagination  .= " <a href='{$uri_path}_offset=" . ($_offset + $limit) . "&$get'>$this->pagination_text_next</a> ";
+            $pagination  .= " <a href='{$uri_path}_offset=" . ($_offset + $limit) . "&amp;$get'>$this->pagination_text_next</a> ";
 
-        $pagination .= " &nbsp; " . number_format($count) . " $this->pagination_text_records <a href='{$uri_path}_pagination_off=1&$get' rel='nofollow'>$this->pagination_text_show_all</a> ";
+        $pagination .= " &nbsp; " . number_format($count) . " $this->pagination_text_records <a href='{$uri_path}_pagination_off=1&amp;$get' rel='nofollow'>$this->pagination_text_show_all</a> ";
 
         $id++;
         return $pagination;
@@ -1843,9 +1843,9 @@ class lazy_mofo{
         $arr = explode(',', trim($query_string_list, ','));
         foreach($arr as $var)
             if(mb_strlen(@$_REQUEST[$var]) > 0)
-                $get .= "&$var=" . urlencode($_REQUEST[$var]);
+                $get .= "&amp;$var=" . urlencode($_REQUEST[$var]);
 
-        return ltrim($get, '&');
+        return ltrim($get, '&amp;');
 
     }
 


### PR DESCRIPTION
Added German language file.

Fixed a typo and a view unescaped ampersands.

It might not be neccessary in HTML5 anymore but `&` in links should be escaped. Also I don't like the red glowing characters everytime I watch the sourcecode in Firefox.